### PR TITLE
Fix rep cut when empty

### DIFF
--- a/gestionatr/output/messages/base.py
+++ b/gestionatr/output/messages/base.py
@@ -82,4 +82,5 @@ def rep_ruedas(n_rodes):
 
 
 def rep_cut(length):
-    return lambda text: unicode(text)[:length].strip()
+    # if empty return text to avoid False
+    return lambda text: text and unicode(text)[:length].strip() or text

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -2311,7 +2311,7 @@ class test_F1(unittest.TestCase):
                 'escalera': '1234567890',
                 'piso': '1234567890',
                 'puerta': '12 4567890',
-                'tipo_aclarador_finca': None,
+                'tipo_aclarador_finca': False,
                 'alcarador_finca': None,
             }
         )


### PR DESCRIPTION
When the field with fixed size (`rep_cut()`) is empty, do not write anything.