### PR TITLE
Manage R1 without CUPS

### DIFF
--- a/gestionatr/input/messages/R1.py
+++ b/gestionatr/input/messages/R1.py
@@ -962,7 +962,7 @@ class MinimumFieldsChecker(object):
         return len(self.r1.variables_detalle_reclamacion) > 0
 
     def check_cups(self):
-        return self.r1.cups
+        return get_rec_attr(self.r1, "cups", False)
 
     def check_fecha_incidente(self):
         for var in self.r1.variables_detalle_reclamacion:

--- a/gestionatr/input/messages/message.py
+++ b/gestionatr/input/messages/message.py
@@ -265,6 +265,12 @@ class Message(MessageBase):
 
     @property
     def cups(self):
+        if self.tipus == 'R1':
+            if utils.get_rec_attr(self, "head.CUPS", False):
+                return utils.get_rec_attr(self, "head.CUPS", "").text.strip()
+            else:
+                return False
+
         ref = self.head.CUPS.text.strip()
         if not ref:
             raise except_f1('Error', u'Documento sin código')


### PR DESCRIPTION
In R1 the CUPS is not allways required. Don't raise error if we don't have cups.