### PR TITLE
FIX 0 measures output

### DIFF
--- a/gestionatr/output/messages/sw_c1.py
+++ b/gestionatr/output/messages/sw_c1.py
@@ -398,7 +398,7 @@ class Medida(XmlModel):
 
     _sort_order = ('medida', 'tipo_dhedm', 'periodo', 'magnitud_medida', 'procedencia', 'ultima_lectura_firme', 'fecha_lectura_firme', 'anomalia', 'comentarios')
 
-    def __init__(self):
+    def __init__(self, drop_empty=False):
         self.medida = XmlField('Medida')
         self.tipo_dhedm = XmlField('TipoDHEdM')
         self.periodo = XmlField('Periodo')

--- a/tests/data/c105.xml
+++ b/tests/data/c105.xml
@@ -85,7 +85,7 @@
                 <Periodo>65</Periodo>
                 <MagnitudMedida>PM</MagnitudMedida>
                 <Procedencia>30</Procedencia>
-                <UltimaLecturaFirme>6.00</UltimaLecturaFirme>
+                <UltimaLecturaFirme>0.00</UltimaLecturaFirme>
                 <FechaLecturaFirme>2003-01-02</FechaLecturaFirme>
                 <Anomalia>01</Anomalia>
                 <Comentarios>Comentario sobre anomalia</Comentarios>

--- a/tests/data/c106.xml
+++ b/tests/data/c106.xml
@@ -69,7 +69,7 @@
                 <Periodo>65</Periodo>
                 <MagnitudMedida>PM</MagnitudMedida>
                 <Procedencia>30</Procedencia>
-                <UltimaLecturaFirme>6.00</UltimaLecturaFirme>
+                <UltimaLecturaFirme>0.00</UltimaLecturaFirme>
                 <FechaLecturaFirme>2003-01-02</FechaLecturaFirme>
                 <Anomalia>01</Anomalia>
                 <Comentarios>Comentario sobre anomalia</Comentarios>

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -247,7 +247,7 @@ class test_C1(unittest.TestCase):
         self.assertEqual(md.periodo, '65')
         self.assertEqual(md.procedencia, '30')
         self.assertEqual(md.tipo_dhedm, '6')
-        self.assertEqual(md.ultima_lectura_firme, '6.00')
+        self.assertEqual(md.ultima_lectura_firme, '0.00')
         md2 = ap.medidas[1]
         self.assertFalse(md2.anomalia)
         self.assertFalse(md2.comentarios)
@@ -311,7 +311,7 @@ class test_C1(unittest.TestCase):
         self.assertEqual(md.periodo, '65')
         self.assertEqual(md.procedencia, '30')
         self.assertEqual(md.tipo_dhedm, '6')
-        self.assertEqual(md.ultima_lectura_firme, '6.00')
+        self.assertEqual(md.ultima_lectura_firme, '0.00')
         md2 = ap.medidas[1]
         self.assertFalse(md2.anomalia)
         self.assertFalse(md2.comentarios)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -90,7 +90,7 @@ class test_C1(unittest.TestCase):
             'periodo': '65',
             'magnitud_medida': 'PM',
             'procedencia': '30',
-            'ultima_lectura_firme': '6.00',
+            'ultima_lectura_firme': '0.00',
             'fecha_lectura_firme': '2003-01-02',
             'anomalia': '01',
             'comentarios': 'Comentario sobre anomalia',


### PR DESCRIPTION
Allow measures 0.0.
The generated XML fails otherwise