### PR TITLE
Dont strip comments f1, spaces are important in some cases.

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -787,7 +787,7 @@ class Ajuste(object):
     @property
     def comentario(self):
         if hasattr(self.ajuste, 'Comentarios'):
-            return self.ajuste.Comentarios.text.strip()
+            return self.ajuste.Comentarios.text
         return None
 
 


### PR DESCRIPTION
Se aplicaba un strip en los comentarios de los F1's, esto es un problema muy grande en algunos casos ya que los espacios son importantes, ahora ya no se hace strip. ej. Suplementos