### PR TITLE
Cambios realizados en A102 debido a nuevas especificaciones de la CNMC

### DIFF
--- a/gestionatr/data/A101.xsd
+++ b/gestionatr/data/A101.xsd
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- editado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Comisión Nacional de los Mercados y la Competencia (Comisión Nacional de los Mercados y la Competencia) -->
-<!-- creadp con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TipoMensajeA101.xsd"/>
 	<xs:include schemaLocation="TiposComplejosCCAA.xsd"/>
+	<xs:annotation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
+	</xs:annotation>
 	<xs:element name="A101">
 		<xs:annotation>
 			<xs:documentation>Version XX CNMC 201X.XX.XX</xs:documentation>

--- a/gestionatr/data/A102.xsd
+++ b/gestionatr/data/A102.xsd
@@ -1,147 +1,20 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<schema xmlns="http://www.w3.org/2001/XMLSchema"
-	targetNamespace="http://localhost/sctd/A102"
-	xmlns:tns="http://localhost/sctd/A102"
-	elementFormDefault="qualified" >
-
-	<include schemaLocation="CommonTagsCONT.xsd"></include>
-	<element name="sctdapplication"
-		type="tns:SctdapplicationA102Type">
-	</element>
-
-	<complexType name="SctdapplicationA102Type">
-		<sequence>
-			<element name="heading" type="tns:HeadingA102Type" maxOccurs="1"
-				minOccurs="1">
-			</element>
-			<element name="a102" type="tns:A102Type"
-				maxOccurs="unbounded" minOccurs="1">
-			</element>
-		</sequence>
-	</complexType>
-
-	<complexType name="HeadingA102Type">
-		<sequence>
-			<element name="dispatchingcode" maxOccurs="1"
-				minOccurs="1">
-				<simpleType>
-					<restriction base="string">
-						<enumeration value="GML"></enumeration>
-						<length value="3"></length>
-					</restriction>
-				</simpleType>
-			</element>
-			<element name="dispatchingcompany" type="tns:AgenteType"
-				maxOccurs="1" minOccurs="1">
-			</element>
-			<element name="destinycompany" type="tns:AgenteType"
-				maxOccurs="1" minOccurs="1">
-			</element>
-			<element name="communicationsdate" type="date" maxOccurs="1"
-				minOccurs="1">
-			</element>
-			<element name="communicationshour" type="time" maxOccurs="1"
-				minOccurs="1">
-			</element>
-			<element name="processcode" maxOccurs="1" minOccurs="1">
-				<simpleType>
-					<restriction base="string">
-						<length value="2"></length>
-						<enumeration value="02"></enumeration>
-					</restriction>
-				</simpleType>
-			</element>
-			<element name="messagetype" maxOccurs="1" minOccurs="1">
-				<simpleType>
-					<restriction base="string">
-						<enumeration value="A1"></enumeration>
-						<minLength value="1"></minLength>
-						<maxLength value="3"></maxLength>
-					</restriction>
-				</simpleType>
-			</element>
-		</sequence>
-	</complexType>
-
-	<complexType name="A102Type">
-		<sequence>
-			<element name="comreferencenum"
-				type="tns:ComreferencenumType" maxOccurs="1" minOccurs="1">
-                <annotation>
-                	<documentation>Nï¿½ Referencia Solicitud Comercializadora</documentation>
-                </annotation>
-			</element>
-			<element name="reqdate" type="date" maxOccurs="1"
-				minOccurs="1">
-                <annotation>
-                	<documentation>Fecha de Solicitud</documentation></annotation>
-			</element>
-			<element name="reqhour" type="time" maxOccurs="1"
-				minOccurs="1">
-                <annotation>
-                	<documentation>Hora de Solicitud</documentation></annotation>
-			</element>
-			<element name="titulartype" type="tns:TitularType"
-				maxOccurs="1" minOccurs="0">
-                <annotation>
-                	<documentation>Tipo de Titular</documentation></annotation>
-			</element>
-			<element name="nationality" type="tns:NationalityType"
-				maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Nacionalidad</documentation>
-				</annotation>
-			</element>
-			<element name="documenttype" type="tns:IdDocumentType"
-				maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Tipo Documento de Identificaciï¿½n</documentation>
-				</annotation>
-			</element>
-			<element name="documentnum" type="tns:DocumentnumType"
-				maxOccurs="1" minOccurs="1">
-                <annotation>
-                	<documentation>Nï¿½ Documento</documentation></annotation>
-			</element>
-			<element name="cups" type="tns:CupsType" maxOccurs="1"
-				minOccurs="1">
-                <annotation>
-                	<documentation>CUPS Solicitud</documentation></annotation>
-			</element>
-			<element name="reqqd" type="tns:QdType" maxOccurs="1"
-				minOccurs="0">
-                <annotation>
-                	<documentation>Caudal Diario Solicitado</documentation>
-                </annotation>
-			</element>
-			<element name="reqestimatedqa" type="tns:QaType"
-				maxOccurs="1" minOccurs="1">
-                <annotation>
-                	<documentation>Caudal Estimado Anual</documentation>
-                </annotation>
-			</element>
-			<element name="modeffectdate"
-				type="tns:ModeloFechaSolicitudType" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Modelo de Fecha Efecto</documentation>
-				</annotation>
-			</element>
-			<element name="reqtransferdate" type="date" maxOccurs="1"
-				minOccurs="0">
-                <annotation>
-                	<documentation>Fecha de Efecto Solicitada</documentation></annotation>
-			</element>
-			<element name="disconnectedserviceaccepted"
-				type="tns:FlagType" maxOccurs="1" minOccurs="1">
-                <annotation>
-                	<documentation>Indicador de que se quiere contratar el suministro independientemente de su estado (suspendido o en proceso de baja por impago)</documentation></annotation>
-			</element>
-			<element name="extrainfo" type="tns:ExtrainfoType"
-				maxOccurs="1" minOccurs="0">
-                <annotation>
-                	<documentation>Observaciones de la Solicitud</documentation>
-                </annotation>
-			</element>
-		</sequence>
-	</complexType>
-</schema>
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="TipoMensajeA102.xsd"/>
+	<xs:include schemaLocation="TiposComplejosCCAA.xsd"/>
+	<xs:annotation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
+	</xs:annotation>
+	<xs:element name="A102">
+		<xs:annotation>
+			<xs:documentation>Version XX CNMC 201X.XX.XX</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Cabecera" type="CabeceraCCAA02"/>
+				<xs:element name="A102" type="A102"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/gestionatr/data/TipoMensajeA101.xsd
+++ b/gestionatr/data/TipoMensajeA101.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- editado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Comisión Nacional de los Mercados y la Competencia (Comisión Nacional de los Mercados y la Competencia) -->
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TiposComplejosCCAA.xsd"/>
 	<xs:include schemaLocation="TiposSencillosCCAA.xsd"/>
 	<xs:annotation>
-		<xs:documentation>Version XX CNMC 201X.XX.XX</xs:documentation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
 	</xs:annotation>
 	<!-- Mensaje de Información Regsitro de Autoconsumo -->
 	<xs:complexType name="A101">

--- a/gestionatr/data/TipoMensajeA102.xsd
+++ b/gestionatr/data/TipoMensajeA102.xsd
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- editado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por PGARCIA (Comisión Nacional de los Mercados y la Competencia) -->
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TiposComplejosCCAA.xsd"/>
 	<xs:include schemaLocation="TiposSencillosCCAA.xsd"/>
 	<xs:include schemaLocation="TipoMensajeRechazoCCAA.xsd"/>
 	<xs:annotation>
-		<xs:documentation>Version XX CNMC 201X.XX.XX</xs:documentation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
 	</xs:annotation>
 	<!-- Mensaje de Información Regsitro de Autoconsumo -->
 	<xs:complexType name="A102">
 		<xs:sequence>
 			<xs:element name="CAU" type="CodigoAutoconsumo"/>
-			<xs:choice>
-				<xs:element name="ActualizacionDatosRegistro" type="TypeActualizacionDatosRegistro"/>
-				<xs:element name="Rechazos" type="RechazoDistribuidorCCAA"/>
-			</xs:choice>
+			<xs:element name="Rechazos" type="RechazoDistribuidorCCAA"/>
 			<xs:element name="Comentarios" type="X4000" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>

--- a/gestionatr/data/TipoMensajeRechazoCCAA.xsd
+++ b/gestionatr/data/TipoMensajeRechazoCCAA.xsd
@@ -1,21 +1,20 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
 <xs:schema xmlns="http://localhost/elegibilidad" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TiposComplejosCCAA.xsd"/>
 	<xs:include schemaLocation="TiposSencillosCCAA.xsd"/>
 	<xs:annotation>
-		<xs:documentation>
-			Version 1.0 CNMC 2019.XX.XX
-		</xs:documentation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
 	</xs:annotation>
 	<!-- Rechazo -->
 	<xs:complexType name="RechazoDistribuidorCCAA">
 		<xs:sequence>
+			<xs:element name="FechaRechazo" type="xs:date"/>
 			<xs:element name="Rechazo" type="Rechazo" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="Rechazo">
 		<xs:sequence>
-			<xs:element name="FechaRechazo" type="xs:date"/>
 			<xs:element name="Secuencial">
 				<xs:simpleType>
 					<xs:restriction base="Decimal2">
@@ -28,7 +27,6 @@
 					<xs:documentation>Tabla 27</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="CUPS" type="Codigo" minOccurs="0"/>
 			<xs:element name="Comentarios">
 				<xs:simpleType>
 					<xs:restriction base="X4000">

--- a/gestionatr/data/TiposComplejosCCAA.xsd
+++ b/gestionatr/data/TiposComplejosCCAA.xsd
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- editado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Comisión Nacional de los Mercados y la Competencia (Comisión Nacional de los Mercados y la Competencia) -->
-<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia) -->
+<!-- creado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Pelayo García Bermejo (Comisión Nacional de los Mercados y la Competencia-->
 <xs:schema xmlns="http://localhost/elegibilidad" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TiposSencillosCCAA.xsd"/>
 	<xs:annotation>
-		<xs:documentation>Version XX CNMC 201X.XX.XX</xs:documentation>
+		<xs:documentation>Version 1.0 CNMC 2019.11.13</xs:documentation>
 	</xs:annotation>
 	<xs:complexType name="CabeceraCCAA01">
 		<xs:sequence>
@@ -322,15 +321,6 @@
 						<xs:whiteSpace value="collapse"/>
 					</xs:restriction>
 				</xs:simpleType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TypeActualizacionDatosRegistro">
-		<xs:sequence>
-			<xs:element name="SubSeccion" type="SubSeccion">
-				<xs:annotation>
-					<xs:documentation>Tabla 128</xs:documentation>
-				</xs:annotation>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>

--- a/gestionatr/input/messages/A1.py
+++ b/gestionatr/input/messages/A1.py
@@ -96,23 +96,13 @@ class A1(Message, ProcessDeadline):
             return False
 
     @property
-    def actualizacion_datos_registro(self):
-        tree = '{0}.ActualizacionDatosRegistro'.format(self._header)
+    def rechazos(self):
+        tree = '{0}.Rechazos'.format(self._header)
         data = get_rec_attr(self.obj, tree, False)
         if data not in [None, False]:
-            return ActualizacionDatosRegistro(data)
+            return Rechazos(data)
         else:
             return False
-
-    @property
-    def rechazos(self):
-        data = []
-        obj = get_rec_attr(self.obj, self._header, False)
-        if (hasattr(obj, 'Rechazos') and
-                hasattr(obj.Rechazos, 'Rechazo')):
-            for d in obj.Rechazos.Rechazo:
-                data.append(Rechazo(d))
-        return data
 
     @property
     def comentarios(self):
@@ -128,16 +118,26 @@ class A1(Message, ProcessDeadline):
         return checker.check()
 
 
-class ActualizacionDatosRegistro(object):
+class Rechazos(object):
 
     def __init__(self, data):
-        self.actualizacion_datos_registro = data
+        self.rechazos = data
 
     @property
-    def sub_seccion(self):
+    def fecha_rechazo(self):
         data = ''
         try:
-            data = self.actualizacion_datos_registro.SubSeccion.text
+            data = self.rechazos.FechaRechazo.text
+        except AttributeError:
+            pass
+        return data
+
+    @property
+    def rechazo(self):
+        data = []
+        try:
+            for rechazo in self.rechazos.Rechazo:
+                data.append(Rechazo(rechazo))
         except AttributeError:
             pass
         return data
@@ -147,15 +147,6 @@ class Rechazo(object):
 
     def __init__(self, data):
         self.rechazo = data
-
-    @property
-    def fecha_rechazo(self):
-        data = ''
-        try:
-            data = self.rechazo.FechaRechazo.text
-        except AttributeError:
-            pass
-        return data
 
     @property
     def secuencial(self):
@@ -171,15 +162,6 @@ class Rechazo(object):
         data = ''
         try:
             data = self.rechazo.CodigoMotivo.text
-        except AttributeError:
-            pass
-        return data
-
-    @property
-    def cups(self):
-        data = ''
-        try:
-            data = self.rechazo.CUPS.text
         except AttributeError:
             pass
         return data
@@ -216,9 +198,7 @@ class MinimumFieldsChecker(object):
                 'identificador', 'telefon', 'pais', 'provincia', 'municipi', 'codi_postal', 'via_or_apartat_correus'
             ]
         elif pas == '02':
-            return [
-                'actualitzacio_dades_regsitre', 'rebuigs'
-            ]
+            return ['cau']
         else:
             return False
 

--- a/gestionatr/output/messages/sw_a1.py
+++ b/gestionatr/output/messages/sw_a1.py
@@ -34,61 +34,47 @@ class InfoRegistroAutoconsA1(XmlModel):
 
 
 # Paso 02
-class MensajeActualizacionRegistroAutoconsumo(XmlModel):
+class MensajeA102(XmlModel):
 
-    _sort_order = ('mensaje', 'cabecera', 'actualizacion_registro_autoconsumo')
+    _sort_order = ('mensaje', 'cabecera', 'a102')
 
     def __init__(self):
         self.mensaje = XmlField('A102',
                                 attributes={'xmlns': 'http://localhost/elegibilidad'})
         self.cabecera = CabeceraAutoconsumoRechazo()
-        self.actualizacion_registro_autoconsumo = ActualizacionRegistroAutoconsumo()
-        super(MensajeActualizacionRegistroAutoconsumo, self).__init__('MensajeActualizacionRegistroAutoconsumo', 'mensaje')
+        self.a102 = A102()
+        super(MensajeA102, self).__init__('MensajeA102', 'mensaje')
 
 
-class ActualizacionRegistroAutoconsumo(XmlModel):
+class A102(XmlModel):
 
-    _sort_order = ('actualizacion_registro_autoconsumo', 'cau', 'actualizacion_datos_registro',
-                   'rechazos', 'comentarios')
+    _sort_order = ('a102', 'cau', 'rechazos', 'comentarios')
 
     def __init__(self):
-        self.actualizacion_registro_autoconsumo = XmlField('A102')
+        self.a102 = XmlField('A102')
         self.cau = XmlField('CAU')
-        self.actualizacion_datos_registro = ActualizacionDatosRegistro()
         self.rechazos = Rechazos()
         self.comentarios = XmlField('Comentarios')
-        super(ActualizacionRegistroAutoconsumo, self).__init__('A102', 'actualizacion_registro_autoconsumo')
-
-
-class ActualizacionDatosRegistro(XmlModel):
-
-    _sort_order = ('actualizacion_datos_registro', 'sub_seccion')
-
-    def __init__(self):
-        self.actualizacion_datos_registro = XmlField('ActualizacionDatosRegistro')
-        self.sub_seccion = XmlField('SubSeccion')
-        super(ActualizacionDatosRegistro, self).__init__('ActualizacionDatosRegistro', 'actualizacion_datos_registro')
-
+        super(A102, self).__init__('A102', 'a102')
 
 class Rechazos(XmlModel):
 
-    _sort_order = ('rechazos', 'rechazo_list')
+    _sort_order = ('rechazos', 'fecha_rechazo', 'rechazo_list')
 
     def __init__(self):
         self.rechazos = XmlField('Rechazos')
+        self.fecha_rechazo = XmlField('FechaRechazo')
         self.rechazo_list = []
         super(Rechazos, self).__init__('Rechazos', 'rechazos')
 
 
 class Rechazo(XmlModel):
 
-    _sort_order = ('rechazo', 'fecha_rechazo', 'secuencial', 'codigo_motivo', 'cups', 'comentarios')
+    _sort_order = ('rechazo', 'secuencial', 'codigo_motivo', 'comentarios')
 
     def __init__(self):
         self.rechazo = XmlField('Rechazo')
-        self.fecha_rechazo = XmlField('FechaRechazo')
         self.secuencial = XmlField('Secuencial')
         self.codigo_motivo = XmlField('CodigoMotivo')
-        self.cups = XmlField('CUPS')
         self.comentarios = XmlField('Comentarios')
         super(Rechazo, self).__init__('Rechazo', 'rechazo')

--- a/tests/data/a102_accept.xml
+++ b/tests/data/a102_accept.xml
@@ -11,9 +11,14 @@
     </Cabecera>
     <A102>
         <CAU>ES1234000000000001JN0FA001</CAU>
-        <ActualizacionDatosRegistro>
-            <SubSeccion>a0</SubSeccion>
-        </ActualizacionDatosRegistro>
+        <Rechazos>
+            <FechaRechazo>2016-06-08</FechaRechazo>
+            <Rechazo>
+                <Secuencial>00</Secuencial>
+                <CodigoMotivo>01</CodigoMotivo>
+                <Comentarios>TODO: ELIMINAR CUANDO LA CNMC ARREGLE EL XSD</Comentarios>
+            </Rechazo>
+        </Rechazos>
         <Comentarios>Esto es un comentario</Comentarios>
     </A102>
 </A102>

--- a/tests/data/a102_reject.xml
+++ b/tests/data/a102_reject.xml
@@ -12,25 +12,20 @@
     <A102>
         <CAU>ES1234000000000001JN0FA001</CAU>
         <Rechazos>
+            <FechaRechazo>2016-06-08</FechaRechazo>
             <Rechazo>
-                <FechaRechazo>2016-06-08</FechaRechazo>
                 <Secuencial>00</Secuencial>
                 <CodigoMotivo>01</CodigoMotivo>
-                <CUPS>ES1234000000000001JN0F</CUPS>
                 <Comentarios>Comentario del rechazo</Comentarios>
             </Rechazo>
             <Rechazo>
-                <FechaRechazo>2016-06-08</FechaRechazo>
                 <Secuencial>00</Secuencial>
                 <CodigoMotivo>F1</CodigoMotivo>
-                <CUPS>ES1234000000000001JN0F</CUPS>
                 <Comentarios>Comentario del rechazo</Comentarios>
             </Rechazo>
             <Rechazo>
-                <FechaRechazo>2016-06-08</FechaRechazo>
                 <Secuencial>00</Secuencial>
                 <CodigoMotivo>F4</CodigoMotivo>
-                <CUPS>ES1234000000000001JN0F</CUPS>
                 <Comentarios>Comentario del rechazo</Comentarios>
             </Rechazo>
         </Rechazos>

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -590,8 +590,6 @@ class test_A1(unittest.TestCase):
         a1.parse_xml()
 
         self.assertEqual(a1.cau, u'ES1234000000000001JN0FA001')
-        registro = a1.actualizacion_datos_registro
-        self.assertEqual(registro.sub_seccion, u'a0')
         self.assertEqual(a1.comentarios, u'Esto es un comentario')
 
     def test_a102_reject(self):
@@ -601,27 +599,22 @@ class test_A1(unittest.TestCase):
         self.assertEqual(a1.cau, u'ES1234000000000001JN0FA001')
         self.assertEqual(a1.comentarios, u'Esto es un comentario')
         rechazos = a1.rechazos
-        self.assertEqual(len(rechazos), 3)
+        self.assertEqual(len(rechazos.rechazo), 3)
+        self.assertEqual(rechazos.fecha_rechazo, u'2016-06-08')
         # Rechazo 1
-        rechazo1 = rechazos[0]
-        self.assertEqual(rechazo1.fecha_rechazo, u'2016-06-08')
+        rechazo1 = rechazos.rechazo[0]
         self.assertEqual(rechazo1.secuencial, u'00')
         self.assertEqual(rechazo1.codigo_motivo, u'01')
-        self.assertEqual(rechazo1.cups, u'ES1234000000000001JN0F')
         self.assertEqual(rechazo1.comentarios, u'Comentario del rechazo')
         # Rechazo 2
-        rechazo2 = rechazos[1]
-        self.assertEqual(rechazo2.fecha_rechazo, u'2016-06-08')
+        rechazo2 = rechazos.rechazo[1]
         self.assertEqual(rechazo2.secuencial, u'00')
         self.assertEqual(rechazo2.codigo_motivo, u'F1')
-        self.assertEqual(rechazo2.cups, u'ES1234000000000001JN0F')
         self.assertEqual(rechazo2.comentarios, u'Comentario del rechazo')
         # Rechazo 3
-        rechazo3 = rechazos[2]
-        self.assertEqual(rechazo3.fecha_rechazo, u'2016-06-08')
+        rechazo3 = rechazos.rechazo[2]
         self.assertEqual(rechazo3.secuencial, u'00')
         self.assertEqual(rechazo3.codigo_motivo, u'F4')
-        self.assertEqual(rechazo3.cups, u'ES1234000000000001JN0F')
         self.assertEqual(rechazo3.comentarios, u'Comentario del rechazo')
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -984,30 +984,40 @@ class test_A1(unittest.TestCase):
             }
             cabecera.feed(cabecera_fields)
 
-            # ActualizacionRegistroAutoconsumo
-            datos_registro = a1.ActualizacionDatosRegistro()
-            actualizacion_datos_registro_fields = {
-                'sub_seccion': 'a0',
+            # Rechazo 1
+            rechazo1 = a1.Rechazo()
+            rechazo1_fields = {
+                'secuencial': '00',
+                'codigo_motivo': '01',
+                'comentarios': 'TODO: ELIMINAR CUANDO LA CNMC ARREGLE EL XSD',
             }
-            datos_registro.feed(actualizacion_datos_registro_fields)
+            rechazo1.feed(rechazo1_fields)
+
+            # Rechazos
+            rechazos = a1.Rechazos()
+            rechazos_fields = {
+                'fecha_rechazo': '2016-06-08',
+                'rechazo_list': [rechazo1],
+            }
+            rechazos.feed(rechazos_fields)
 
             # ActualizacionRegistroAutoconsumo
-            registro = a1.ActualizacionRegistroAutoconsumo()
-            actualizacion_registro_autoconsumo_fields = {
+            a102 = a1.A102()
+            a102_fields = {
                 'cau': 'ES1234000000000001JN0FA001',
-                'actualizacion_datos_registro': datos_registro,
+                'rechazos': rechazos,
                 'comentarios': 'Esto es un comentario',
 
             }
-            registro.feed(actualizacion_registro_autoconsumo_fields)
+            a102.feed(a102_fields)
 
             # MensajeActualizacionRegistroAutoconsumo
-            mensaje = a1.MensajeActualizacionRegistroAutoconsumo()
-            mensaje_actualizacion_registro_autoconsumo_fields = {
+            mensaje = a1.MensajeA102()
+            mensaje_a102_fields = {
                 'cabecera': cabecera,
-                'actualizacion_registro_autoconsumo': registro,
+                'a102': a102,
             }
-            mensaje.feed(mensaje_actualizacion_registro_autoconsumo_fields)
+            mensaje.feed(mensaje_a102_fields)
 
             mensaje.build_tree()
             xml = str(mensaje)
@@ -1030,58 +1040,53 @@ class test_A1(unittest.TestCase):
             # Rechazo 1
             rechazo1 = a1.Rechazo()
             rechazo1_fields = {
-                'fecha_rechazo': '2016-06-08',
                 'secuencial': '00',
                 'codigo_motivo': '01',
-                'cups': 'ES1234000000000001JN0F',
                 'comentarios': 'Comentario del rechazo',
             }
             rechazo1.feed(rechazo1_fields)
             # Rechazo 2
             rechazo2 = a1.Rechazo()
             rechazo2_fields = {
-                'fecha_rechazo': '2016-06-08',
                 'secuencial': '00',
                 'codigo_motivo': 'F1',
-                'cups': 'ES1234000000000001JN0F',
                 'comentarios': 'Comentario del rechazo',
             }
             rechazo2.feed(rechazo2_fields)
             # Rechazo 3
             rechazo3 = a1.Rechazo()
             rechazo3_fields = {
-                'fecha_rechazo': '2016-06-08',
                 'secuencial': '00',
                 'codigo_motivo': 'F4',
-                'cups': 'ES1234000000000001JN0F',
                 'comentarios': 'Comentario del rechazo',
             }
             rechazo3.feed(rechazo3_fields)
 
             # Rechazos
-            rechazos = d1.Rechazos()
+            rechazos = a1.Rechazos()
             rechazos_fields = {
-                'rechazos': [rechazo1, rechazo2, rechazo3],
+                'fecha_rechazo': '2016-06-08',
+                'rechazo_list': [rechazo1, rechazo2, rechazo3],
             }
             rechazos.feed(rechazos_fields)
 
             # ActualizacionRegistroAutoconsumo
-            registro = a1.ActualizacionRegistroAutoconsumo()
-            actualizacion_registro_autoconsumo_fields = {
+            a102 = a1.A102()
+            a102_fields = {
                 'cau': 'ES1234000000000001JN0FA001',
                 'rechazos': rechazos,
                 'comentarios': 'Esto es un comentario',
 
             }
-            registro.feed(actualizacion_registro_autoconsumo_fields)
+            a102.feed(a102_fields)
 
             # MensajeActualizacionRegistroAutoconsumo
-            mensaje = a1.MensajeActualizacionRegistroAutoconsumo()
-            mensaje_actualizacion_registro_autoconsumo_fields = {
+            mensaje = a1.MensajeA102()
+            mensaje_a102_fields = {
                 'cabecera': cabecera,
-                'actualizacion_registro_autoconsumo': registro,
+                'a102': a102,
             }
-            mensaje.feed(mensaje_actualizacion_registro_autoconsumo_fields)
+            mensaje.feed(mensaje_a102_fields)
 
             mensaje.build_tree()
             xml = str(mensaje)


### PR DESCRIPTION
Cambios realizados en A102 debido a nuevas especificaciones de la CNMC.

Se modifica el paso A102 de la siguiente manera:
- Se elimina el boque 'ActualizacionDatosRegistro' de la aceptación
- Se mueve la 'FechaRechazo' fuera de los Rechazos individuales al bloque superior 'Rechazos'
- Se elimina el CUPS informado en los rechazos.

Se detecta un bug en el XSD 'TipoMensajeA102.xsd' por el que se obliga a informar rechazos aunque se trate de un mensaje de aceptación.

Se añaden los XSD oportunos.