### PR TITLE
Utilizar InfoRegistroAutocons (con 's') si InfoRegistoAutocons (sin 's') no està informado

### DIFF
--- a/gestionatr/input/messages/D1.py
+++ b/gestionatr/input/messages/D1.py
@@ -40,7 +40,7 @@ class D1(C1):
         if data not in [None, False]:
             return InfoRegistroAutocons(data)
         else:
-            tree = '{0}.InfoRegistoAutocons'.format(self._header)
+            tree = '{0}.InfoRegistroAutocons'.format(self._header)
             data = get_rec_attr(self.obj, tree, False)
             if data not in [None, False]:
                 return InfoRegistroAutocons(data)


### PR DESCRIPTION
Utilizar InfoRegistroAutocons (con 's') si InfoRegistoAutocons (sin 's') no està informado.

Algunas distribuidoras lo envian mal y con este minimo cambio ya se puede importar el D1