### PR TITLE
No se contempla el tag IVAReducido

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -366,6 +366,9 @@ class Factura(object):
         if hasattr(self.factura, 'IVA'):
             for d in self.factura.IVA:
                 data.append(IVA(d))
+        if hasattr(self.factura, 'IVAReducido'):
+            for d in self.factura.IVAReducido:
+                data.append(IVA(d))
         return data
 
     @property


### PR DESCRIPTION
# Problema
Algunos F1 no se cargan correctamente: salta el error `2002` conforme el total de la factura de proveedor creada no coincide con el del F1 cargado

# Causa
El F1 cargado **no** tiene impuestos en el tag `IVA` (es una compensación) pero si que tiene en el tag `IVAReducido`. El proceso de carga de F1 asigna los impuestos a las lineas de la factura solamente si el tag de `IVA` tiene impuestos. Al no tenerlos, ignora las impuestos de `IVAReducido` y crea las líneas sin impuesto alguno provocando que el importe de la factura no cuadre con el del F1.

# Tests
Se pueden encontrar en https://github.com/gisce/erp/pull/10699
