### PR TITLE
Millores en les lectures i ajustos per autoconsum

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1348,43 +1348,15 @@ class FacturaATR(Factura):
                     lectures_per_periode[periode] = []
                 lectures_per_periode[periode].append(lectura)
 
-        if tipus == "S" and not lectures_per_periode and self.get_consum_facturat(tipus='S', periode=None):
-            # Si ens han facturat excedents pero no ens han informat de cap lectura AS,
-            # ens inventem lectures amb valor 0 (puta ENDESA que ens fa perdre el temps)
-            comptador_amb_lectures = None
-            for c in self.get_comptadors():
-                if c.get_lectures_activa_entrant():
-                    comptador_amb_lectures = c
-                    break
-            if comptador_amb_lectures:
-                base_info = comptador_amb_lectures.get_lectures_activa_entrant()[0]
-                for concepte in self.conceptos_repercutibles:
-                    if concepte.concepto_repercutible[0] == '7':
-                        l1 = Lectura(None)
-                        l1.fecha = base_info.lectura_desde.fecha
-                        l1.lectura = 0
-                        l2 = Lectura(None)
-                        l2.fecha = base_info.lectura_hasta.fecha
-                        l2.lectura = 0
-                        new_integrador = Integrador(None)
-                        new_integrador.magnitud = "AS"
-                        new_integrador.codigo_periodo = base_info.codigo_periodo[0] + concepte.concepto_repercutible[1]
-                        new_integrador.lectura_desde = l1
-                        new_integrador.lectura_hasta = l2
-                        periode = 'P'+concepte.concepto_repercutible[1]
-                        if not lectures_per_periode.get(periode):
-                            lectures_per_periode[periode] = []
-                        lectures_per_periode[periode].append(new_integrador)
-
-        nperiodes = len([l for l in lectures_per_periode.keys() if l])
-        if self.periodes_facturats_agrupats(nperiodes, tipus=tipus) and ajust_balancejat:
-            for periode in lectures_per_periode.keys():
-                if not periode:
-                    continue
-                periode_agrupat = "P{0}".format(int(periode[1:]) + nperiodes/2)
-                if lectures_per_periode.get(periode_agrupat):
-                    lectures_per_periode[periode].extend(lectures_per_periode.get(periode_agrupat))
-                    del lectures_per_periode[periode_agrupat]
+            nperiodes = len([l for l in lectures_per_periode.keys() if l])
+            if self.periodes_facturats_agrupats(nperiodes, tipus=tipus) and ajust_balancejat:
+                for periode in lectures_per_periode.keys():
+                    if not periode:
+                        continue
+                    periode_agrupat = "P{0}".format(int(periode[1:]) + nperiodes/2)
+                    if lectures_per_periode.get(periode_agrupat):
+                        lectures_per_periode[periode].extend(lectures_per_periode.get(periode_agrupat))
+                        del lectures_per_periode[periode_agrupat]
 
         res = {}
         for periode, lectures in lectures_per_periode.iteritems():

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -873,6 +873,7 @@ class Integrador(object):
         self._lectura_hasta = None
         self._magnitud = None
         self._periode = None
+        self._numero_ruedas_enteras = None
         self._ajuste = None
         self.comptador = None
 
@@ -912,9 +913,15 @@ class Integrador(object):
 
     @property
     def numero_ruedas_enteras(self):
+        if self._numero_ruedas_enteras:
+            return self._numero_ruedas_enteras
         if hasattr(self.integrador, 'NumeroRuedasEnteras'):
             return float(self.integrador.NumeroRuedasEnteras.text.strip())
         return None
+
+    @numero_ruedas_enteras.setter
+    def numero_ruedas_enteras(self, value):
+        self._numero_ruedas_enteras = value
 
     @property
     def numero_ruedas_decimales(self):
@@ -1324,6 +1331,7 @@ class FacturaATR(Factura):
                     l2.procedencia = base_info.lectura_hasta.procedencia
                     new_integrador = Integrador(None)
                     new_integrador.magnitud = "AS"
+                    new_integrador.numero_ruedas_enteras = base_info.numero_ruedas_enteras
                     new_integrador.codigo_periodo = base_info.codigo_periodo[0] + concepte.concepto_repercutible[1]
                     new_integrador.lectura_desde = l1
                     new_integrador.lectura_hasta = l2

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1277,7 +1277,7 @@ class FacturaATR(Factura):
                         lectura.ajuste = Ajuste(lectura.ajuste.ajuste)
                     old_ajust = lectura.ajuste and lectura.ajuste.ajuste_por_integrador or 0.0
                     new_val = consum - (lectura.lectura_hasta.lectura - lectura.lectura_desde.lectura + old_ajust)
-                    if new_val != 0.0:
+                    if new_val != (lectura.lectura_hasta.lectura - lectura.lectura_desde.lectura + old_ajust):
                         lectura.ajuste.ajuste_por_integrador = consum - (lectura.lectura_hasta.lectura - lectura.lectura_desde.lectura)
                         lectura.ajuste.codigo_motivo = motiu_ajust  # normalment 98 - Autoconsumo
             for l in lectures:


### PR DESCRIPTION
- Repartir ajustos autoconsum  entre els periodes per evitar voltes de contador 
- Quan ens cobren excedents pero no ens informen lectures, ens inventem unes lectures AS a 0 per poder processar el F1