### PR TITLE
Cuando ruedas enteras del contador con lectura 0 el fake devolvia non…

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -930,7 +930,7 @@ class Integrador(object):
 
     @property
     def numero_ruedas_enteras(self):
-        if self._numero_ruedas_enteras:
+        if self._numero_ruedas_enteras is not None:
             return self._numero_ruedas_enteras
         if hasattr(self.integrador, 'NumeroRuedasEnteras'):
             return float(self.integrador.NumeroRuedasEnteras.text.strip())


### PR DESCRIPTION
Solucionar problemas con las lecturas fake:
  - Al crear las lecturas e integrador Fake hay un problema con los nuevos getters, ya quela mayoria la condicion es if X devuelve, pero el problema estava cuando un valor era 0 ya que directamente se saltaba la condicion hacia un return None lo que al mismo tiempo hace que los nuevos datos se seten mal y realize mal calculos como el giro de contador

Este F1 tenia una lectura y ha creado una fake, _numero_ruedas_enteras del integrador fake se ha seteado con None ya que el getter del contador con lecturas tenia como ruedas enteras 0.0 y su getter devolvia None

{'_lectura_hasta': None, '_magnitud': None, '_ajuste': None, '_periode': None, '_numero_ruedas_enteras': None, 'integrador': <Element {http://localhost/elegibilidad}Integrador at 0x7f404a776ab8>, 'comptador': None, '_lectura_desde': None}
{'_lectura_hasta': <gestionatr.input.messages.F1.Lectura object at 0x7f403a632390>, '_magnitud': 'AS', '_ajuste': None, '_periode': '10', '_numero_ruedas_enteras': 0.0, 'integrador': None, 'comptador': None, '_lectura_desde': <gestionatr.input.messages.F1.Lectura object at 0x7f403a632d50>}

entonces al ir a calcular el giro:

fake.gir_comptador
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-75-43e84bc375a8> in <module>()
----> 1 fake.gir_comptador

/home/psala/.virtualenvs/erp/local/lib/python2.7/site-packages/gestionatr/input/messages/F1.pyc in gir_comptador(self)
    989         if self.numero_ruedas_enteras == 99:
    990             return 10
--> 991         return 10 ** self.numero_ruedas_enteras
    992 
    993     @property

TypeError: unsupported operand type(s) for ** or pow(): 'int' and 'NoneType'


