### PR TITLE
Permitir poblaciones de menos de 11 caracteres

### DIFF
--- a/gestionatr/data/TiposComplejos.xsd
+++ b/gestionatr/data/TiposComplejos.xsd
@@ -548,7 +548,6 @@
 			<xs:element name="Poblacion" minOccurs="0">
 				<xs:simpleType>
 					<xs:restriction base="X11">
-						<xs:minLength value="11"/>
 						<xs:pattern value="[0-9]*"/>
 					</xs:restriction>
 				</xs:simpleType>
@@ -646,7 +645,6 @@
 			<xs:element name="Poblacion" minOccurs="0">
 				<xs:simpleType>
 					<xs:restriction base="X11">
-						<xs:minLength value="11"/>
 						<xs:pattern value="[0-9]*"/>
 					</xs:restriction>
 				</xs:simpleType>
@@ -1232,7 +1230,6 @@
 			<xs:element name="Poblacion" minOccurs="0">
 				<xs:simpleType>
 					<xs:restriction base="X11">
-						<xs:minLength value="11"/>
 						<xs:pattern value="[0-9]*"/>
 					</xs:restriction>
 				</xs:simpleType>
@@ -1411,7 +1408,6 @@
 			<xs:element name="Poblacion" minOccurs="0">
 				<xs:simpleType>
 					<xs:restriction base="X11">
-						<xs:minLength value="11"/>
 						<xs:pattern value="[0-9]*"/>
 					</xs:restriction>
 				</xs:simpleType>

--- a/gestionatr/data/TiposSencillos.xsd
+++ b/gestionatr/data/TiposSencillos.xsd
@@ -3401,7 +3401,7 @@ la reclamacion
 	</xs:simpleType>
 	<xs:simpleType name="X11">
 		<xs:restriction base="xs:string">
-			<xs:minLength value="11"/>
+			<xs:minLength value="5"/>
 			<xs:maxLength value="11"/>
 		</xs:restriction>
 	</xs:simpleType>

--- a/gestionatr/input/messages/C1.py
+++ b/gestionatr/input/messages/C1.py
@@ -461,7 +461,7 @@ class Contrato(object):
     def data_finalitzacio(self):
         data = ''
         try:
-            data = self.contrato.FechaFinalizacion.text
+            data = self.contrato.IdContrato.FechaFinalizacion.text
         except AttributeError:
             pass
         return data
@@ -470,7 +470,7 @@ class Contrato(object):
     def fecha_finalizacion(self):
         data = ''
         try:
-            data = self.contrato.FechaFinalizacion.text
+            data = self.contrato.IdContrato.FechaFinalizacion.text
         except AttributeError:
             pass
         return data

--- a/gestionatr/input/messages/C1.py
+++ b/gestionatr/input/messages/C1.py
@@ -461,7 +461,7 @@ class Contrato(object):
     def data_finalitzacio(self):
         data = ''
         try:
-            data = self.contrato.IdContrato.FechaFinalizacion.text
+            data = self.contrato.FechaFinalizacion.text
         except AttributeError:
             pass
         return data
@@ -470,7 +470,7 @@ class Contrato(object):
     def fecha_finalizacion(self):
         data = ''
         try:
-            data = self.contrato.IdContrato.FechaFinalizacion.text
+            data = self.contrato.FechaFinalizacion.text
         except AttributeError:
             pass
         return data


### PR DESCRIPTION
Se permiten poblaciones de menos de 11 caracteres aunque segun la CNMC deban tener 11 caracteres ya que la mayoria de distribuidoras no cumplen el requisito y resulta en ficheros que no se pueden processar