### PR TITLE
Evitar milisegundos en fecha de solicitud de casos ATR de electricidad

### DIFF
--- a/gestionatr/input/messages/message.py
+++ b/gestionatr/input/messages/message.py
@@ -370,7 +370,7 @@ class Message(MessageBase):
         ref = self.head.FechaSolicitud.text
         if not ref:
             raise except_f1('Error', u'Documento sin fecha de solicitud')
-        return ' '.join(ref.split('T'))
+        return ' '.join(ref.split('T')).split('.')[0]
 
 
 class except_f1(Exception):


### PR DESCRIPTION
Algunas empresas envían la fecha de solicitud con milisegundos. Se eliminan dichos milisegundos para no afectar a la carga de ficheros switching