### PR TITLE
FIX Recuperar valores de coeficiente de reparto

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -491,7 +491,7 @@ class Factura(object):
                     if instalacio.EnergiaNetaGen:
                         for terme in instalacio.EnergiaNetaGen.TerminoEnergiaNetaGen:
                             for periode in terme.Periodo:
-                                if periode.ValorEnergiaNetaGen:
+                                if float(periode.ValorEnergiaNetaGen.text):
                                     beta_list.append(float(periode.Beta.text))
                 return list(set(beta_list))
         except AttributeError:


### PR DESCRIPTION
No se evalua bien los valores de ValorEnergiaNetaGen como True o False. Convertimos el valor del texto del nodo a float i evaluamos.