### PR TITLE
Añade conceptos 84 y 85 para electrointensivos.

### DIFF
--- a/gestionatr/data/TiposSencillos.xsd
+++ b/gestionatr/data/TiposSencillos.xsd
@@ -362,6 +362,8 @@
 			81	Tipo de autoconsumo
 			82	Coeficiente de reparto
 			83  Recargo por la no dedicación exclusiva de la carga a vehículos eléctricos
+			84  Descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva
+			85  Regularización descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
@@ -415,6 +417,8 @@
 			<xs:enumeration value="81"/>
 			<xs:enumeration value="82"/>
 			<xs:enumeration value="83"/>
+			<xs:enumeration value="84"/>
+			<xs:enumeration value="85"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="Decimal10">

--- a/gestionatr/defs.py
+++ b/gestionatr/defs.py
@@ -2176,6 +2176,8 @@ TABLA_103 = [
     ('81', u'Tipo de autoconsumo'),
     ('82', u'Coeficiente de reparto'),
     ('83', u'Recargo por la no dedicación exclusiva de la carga a vehículos eléctricos'),
+    ('84', u'Descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva'),
+    ('85', u'Regularización descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva'),
 ]
 
 CONCEPTOS_CON_FECHA_OPERACION = [


### PR DESCRIPTION
Se añade conceptos 84 y 85 para electrointensivos:

- '84', 'Descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva'
- '85', 'Regularización descuento en peajes de transporte y distribución de electricidad a la industria electrointensiva'