### PR TITLE
Escoger correctamente las fechas al crear una modcon al importar un B70

### DIFF
--- a/gestionatr/input/messages/B70.py
+++ b/gestionatr/input/messages/B70.py
@@ -603,8 +603,6 @@ class Factura(object):
             - data inici: la mes antiga de les fecdesde dels conceptes
             - data fi: la mes nova de les fechasta dels conceptes
         """
-        t_variable = "tvariable" in TIPUS_CONCEPTES.get(x.codconcepto, "")
-        t_fix = "tfix" in TIPUS_CONCEPTES.get(x.codconcepto, "")
         return (
             min([x.fecdesde for x in self.listaconceptos if
                  "tvariable" in TIPUS_CONCEPTES.get(x.codconcepto, "") or "tfix" in TIPUS_CONCEPTES.get(x.codconcepto, "")]

--- a/gestionatr/input/messages/B70.py
+++ b/gestionatr/input/messages/B70.py
@@ -598,6 +598,22 @@ class Factura(object):
             max([x.fechasta for x in self.listaconceptos])
         )
 
+    def get_periode_factura_peatges(self):
+        """Retorna tupla amb (data inici,  data fi) de la factura:
+            - data inici: la mes antiga de les fecdesde dels conceptes
+            - data fi: la mes nova de les fechasta dels conceptes
+        """
+        t_variable = "tvariable" in TIPUS_CONCEPTES.get(x.codconcepto, "")
+        t_fix = "tfix" in TIPUS_CONCEPTES.get(x.codconcepto, "")
+        return (
+            min([x.fecdesde for x in self.listaconceptos if
+                 "tvariable" in TIPUS_CONCEPTES.get(x.codconcepto, "") or "tfix" in TIPUS_CONCEPTES.get(x.codconcepto, "")]
+                ),
+            max([x.fechasta for x in self.listaconceptos if
+                 "tvariable" in TIPUS_CONCEPTES.get(x.codconcepto, "") or "tfix" in TIPUS_CONCEPTES.get(x.codconcepto, "")]
+                )
+        )
+
     def is_only_conceptes(self):
         has_only_conceptes = True
         for type in self.get_linies_factura_by_type():


### PR DESCRIPTION
## Objetivos

- Al crear una modificación contractual cuando se importa un B70, se tienen que escoger las fechas de inicio y fin según el tipo de concepto de esta. Vamos a escoger las fechas de los conceptos que sean de término fijo o de término variable

## Comportamiento antiguo

- Se escogian mal las fechas de inicio y de fin para crear la nueva modificación contractual

## Comportamiento nuevo

- Se ha creado un nuevo método que nos filtra, a la hora de buscar las fechas, según los conceptos del B70

## Afectaciones / Migración de datos

- [ ] Código. Reiniciar servicios
