### PR TITLE
Mejorar la gestión de F1 para poder comunicar el valor energético medio de tu Codigo Postal

### DIFF
--- a/gestionatr/data/Facturacion.xsd
+++ b/gestionatr/data/Facturacion.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
-<!-- editado con XMLSpy v2015 rel. 3 sp1 (x64) (http://www.altova.com) por Comisión Nacional de los Mercados y la Competencia (Comisión Nacional de los Mercados y la Competencia) -->
+<!-- editado con XMLSpy v2020 rel. 2 (x64) (http://www.altova.com) por Teresa Rodriguez-Losada (INECO) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:include schemaLocation="TiposSencillos.xsd"/>
 	<xs:include schemaLocation="TiposComplejos.xsd"/>
@@ -596,6 +596,19 @@
 													</xs:element>
 												</xs:sequence>
 											</xs:complexType>
+										</xs:element>
+										<xs:element name="ValorEnergiaMediaCP" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>En Kwh</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:decimal">
+													<xs:totalDigits value="13"/>
+													<xs:fractionDigits value="2"/>
+													<xs:maxInclusive value="99999999999.99"/>
+													<xs:minInclusive value="-99999999999.99"/>
+												</xs:restriction>
+											</xs:simpleType>
 										</xs:element>
 									</xs:sequence>
 								</xs:complexType>

--- a/gestionatr/data/TiposComplejos.xsd
+++ b/gestionatr/data/TiposComplejos.xsd
@@ -1064,7 +1064,7 @@
 			<xs:element name="FechaPrevistaAplicacionCambioATR" type="xs:date" minOccurs="0"/>
 			<xs:element name="PeriodicidadFacturacion" type="PeriodicidadFacturacion" minOccurs="0"/>
 			<xs:element name="InfoRegistroAutocons" type="TypeInfoRegistroAutocons" minOccurs="0"/>
-			<xs:element name="InfoRetardoActivAutocons" type="TypeInfoRetardoActivAutocons" minOccurs="0" maxOccurs="6"/>
+			<xs:element name="InfoRetardoActivAutocons" type="TypeInfoRetardoActivAutocons" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="Potencias">
@@ -1624,6 +1624,19 @@
 						</xs:element>
 					</xs:sequence>
 				</xs:complexType>
+			</xs:element>
+			<xs:element name="ValorEnergiaMediaCP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>En Kwh</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:decimal">
+						<xs:totalDigits value="13"/>
+						<xs:fractionDigits value="2"/>
+						<xs:maxInclusive value="99999999999.99"/>
+						<xs:minInclusive value="-99999999999.99"/>
+					</xs:restriction>
+				</xs:simpleType>
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>

--- a/gestionatr/data/TiposSencillos.xsd
+++ b/gestionatr/data/TiposSencillos.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="iso-8859-1"?>
+<!-- editado con XMLSpy v2020 rel. 2 (x64) (http://www.altova.com) por Teresa Rodriguez-Losada (INECO) -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://localhost/elegibilidad" targetNamespace="http://localhost/elegibilidad" elementFormDefault="qualified" attributeFormDefault="unqualified">
 	<xs:simpleType name="AltaBajaModificacion">
 		<xs:annotation>
@@ -428,6 +429,8 @@
 			<xs:enumeration value="G3"/>
 			<xs:enumeration value="G6"/>
 			<xs:enumeration value="H4"/>
+			<xs:enumeration value="H5"/>
+			<xs:enumeration value="H6"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="CodigoMotivoRechazoP0">

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1764,6 +1764,12 @@ class InformacionAlConsumidor(object):
         return None
 
     @property
+    def valor_energia_media_cp(self):
+        if hasattr(self.informacion_al_consumidor, 'ValorEnergiaMediaCP'):
+            return float(self.informacion_al_consumidor.ValorEnergiaMediaCP.text.strip())
+        return None
+
+    @property
     def periodos(self):
         data = []
         periodes_no_facturables = []

--- a/gestionatr/output/messages/sw_f1.py
+++ b/gestionatr/output/messages/sw_f1.py
@@ -821,13 +821,14 @@ class Ajuste(XmlModel):
 class InformacionAlConsumidor(XmlModel):
 
     _sort_order = (
-        'informacion_al_consumidor', 'fecha_inicio_anio_movil', 'periodos'
+        'informacion_al_consumidor', 'fecha_inicio_anio_movil', 'periodos', 'valor_energia_media_cp'
     )
 
     def __init__(self):
         self.informacion_al_consumidor = XmlField('InformacionAlConsumidor')
         self.fecha_inicio_anio_movil = XmlField('FechaInicioAnioMovil', rep=rep_fecha_sin_hora)
         self.periodos = PeriodoInfoAlConsumidor()
+        self.valor_energia_media_cp = XmlField('ValorEnergiaMediaCP')
         super(InformacionAlConsumidor, self).__init__('InformacionAlConsumidor', 'informacion_al_consumidor')
 
 

--- a/tests/data/f101_factura_atr.xml
+++ b/tests/data/f101_factura_atr.xml
@@ -124,6 +124,7 @@
                 <Periodo>
                     <PotenciaMaxDemandadaAnioMovil>3000</PotenciaMaxDemandadaAnioMovil>
                 </Periodo>
+                <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
             </InformacionAlConsumidor>
         </FacturaATR>
         <RegistroFin>

--- a/tests/data/f101_factura_atr_autoconsum_20td.xml
+++ b/tests/data/f101_factura_atr_autoconsum_20td.xml
@@ -126,6 +126,7 @@
                         <Periodo>
                             <ValorEnergiaExcedentaria>116.76</ValorEnergiaExcedentaria>
                         </Periodo>
+                        <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
                     </TerminoEnergiaExcedentaria>
                     <ValorTotalEnergiaExcedentaria>0.00</ValorTotalEnergiaExcedentaria>
                 </EnergiaExcedentaria>

--- a/tests/data/f101_factura_atr_autoconsum_20td.xml
+++ b/tests/data/f101_factura_atr_autoconsum_20td.xml
@@ -126,7 +126,6 @@
                         <Periodo>
                             <ValorEnergiaExcedentaria>116.76</ValorEnergiaExcedentaria>
                         </Periodo>
-                        <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
                     </TerminoEnergiaExcedentaria>
                     <ValorTotalEnergiaExcedentaria>0.00</ValorTotalEnergiaExcedentaria>
                 </EnergiaExcedentaria>
@@ -420,6 +419,7 @@
                 <Periodo>
                     <PotenciaMaxDemandadaAnioMovil>4045</PotenciaMaxDemandadaAnioMovil>
                 </Periodo>
+                <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
             </InformacionAlConsumidor>
         </FacturaATR>
         <RegistroFin>

--- a/tests/data/f101_factura_atr_direccion_suministro.xml
+++ b/tests/data/f101_factura_atr_direccion_suministro.xml
@@ -125,6 +125,7 @@
                 <Periodo>
                     <PotenciaMaxDemandadaAnioMovil>3000</PotenciaMaxDemandadaAnioMovil>
                 </Periodo>
+                <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
             </InformacionAlConsumidor>
         </FacturaATR>
         <RegistroFin>

--- a/tests/data/f101_factura_atr_medidas_baja.xml
+++ b/tests/data/f101_factura_atr_medidas_baja.xml
@@ -126,6 +126,7 @@
                 <Periodo>
                     <PotenciaMaxDemandadaAnioMovil>3000</PotenciaMaxDemandadaAnioMovil>
                 </Periodo>
+                <ValorEnergiaMediaCP>61083.25</ValorEnergiaMediaCP>
             </InformacionAlConsumidor>
         </FacturaATR>
         <RegistroFin>

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -1962,6 +1962,8 @@ class test_F1(unittest.TestCase):
 
         self.assertEqual(periodo_max.potencia_max_demandada_anio_movil, 3000)
 
+        self.assertEqual(info_al_consumidor.valor_energia_media_cp, 61083.25)
+
         registro = f1.registro
 
         self.assertEqual(registro.importe_total, 76.48)
@@ -2418,6 +2420,8 @@ class test_F1(unittest.TestCase):
 
         periodo_max_2 = info_al_consumidor.periodos[1]
         self.assertEqual(periodo_max_2.potencia_max_demandada_anio_movil, 4045)
+
+        self.assertEqual(info_al_consumidor.valor_energia_media_cp, 61083.25)
 
         registro = f1.registro
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -5275,7 +5275,8 @@ class test_F1(unittest.TestCase):
         informacion_al_consumidor.feed(
             {
                 'fecha_inicio_anio_movil': '2017-03-31',
-                'periodos': periodos_maximetros
+                'periodos': periodos_maximetros,
+                'valor_energia_media_cp': 61083.25
             }
         )
 


### PR DESCRIPTION
## Objetivos

- Comunicar la energía consumida por código postal por cada mes natural.