### PR TITLE
Cambio de nombre motivo 15 D101 de alta autoconsumo

### DIFF
--- a/gestionatr/data/TiposSencillos.xsd
+++ b/gestionatr/data/TiposSencillos.xsd
@@ -1924,6 +1924,7 @@
 			11	Falta fichero coeficientes del año que inicia
 			13	Información aplicación descuento por retardo en activación autoconsumo imputable al distribuidor
 			14	Información aplicación descuento por retardo en activación autoconsumo NO imputable al distribuidor
+			15	Alta en autoconsumo colectivo comunicada por un representante
 			</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:string">
@@ -1940,6 +1941,7 @@
 			<xs:enumeration value="11"/>
 			<xs:enumeration value="13"/>
 			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="MotivoFacturacion">

--- a/gestionatr/defs.py
+++ b/gestionatr/defs.py
@@ -2249,7 +2249,7 @@ TABLA_109 = [('01', u'Telegestión Operativa con CCH'),
              ('11', u'Pendiente envío de fichero de coeficientes de reparto variables para el año en curso'),
              ('13', u'Información aplicación descuento por retardo en activación autoconsumo imputable al distribuidor'),
              ('14', u'Información aplicación descuento por retardo en activación autoconsumo NO imputable al distribuidor'),
-             ('15', u'Alta en autoconsumo colectivo comunicada por un participante'),
+             ('15', u'Alta en autoconsumo colectivo comunicada por un representante'),
              ]
 
 TABLA_110 = [('01', u'Acompaña curva de carga'),


### PR DESCRIPTION
El motivo 15 cambia de texto:
De     "Alta en autoconsumo colectivo comunicada por un participante"
A       "Alta en autoconsumo colectivo comunicada por un representante"