### PR TITLE
FIX Al importar lecturas de pool de F1 con unico periodo de nuevas tarifas se creaban mal los ajustes

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1637,7 +1637,7 @@ class ModeloAparato(object):
             lectures.extend(self.factura.get_fake_AS_lectures())
         if (not tipus or "S" in tipus) and self.factura and self.factura.has_AS_lectures_only_p0() \
                 and len(self.factura.get_consum_facturat(tipus='S', periode=None)) > 1 \
-                and self.factura.datos_factura.tarifa_atr_fact not in ['001', '005']:
+                and self.factura.datos_factura.tarifa_atr_fact in ['004', '006', '007', '008']:
             # Si nomes ens envien el P0 de excedents pero ens cobren varis periodes
             # creem una lectura e P2 AS ficticies a 0 (puta FENOSA)
             lectures.extend(self.factura.get_fake_AS_p2_lectures())


### PR DESCRIPTION
## Causa del error

La función `get_fake_AS_p2_lectures` se llamaba cuando un se cogian las lecturas de un F1 que venia con solo una lectura para energia exportada y se creaban 2 lecturas "falsas". El problema era que esto se hacia también cuando se importaban lecturas de pool de un F1 de un contrato con tarifa 2.0TD(con motivo de ajuste "FORZADO DEBIDO A LA NO ADAPTACIÓN A LA TARIFA) que solo tenia una lectura para un periodo de energia entrante y energia saliente. Se ha cambiado la condición para que la función se llame `get_fake_AS_p2_lectures` cuando se trate de antiguas tarifas 
Para las nuevas se utiliza la función `transforma_no_td_a_td` que pasa de tarifa antigua a tarifa nueva y lo que pasaba es que si se llamaba `get_fake_AS_p2_lectures` despues las lecturas no eran compatibles con  `transforma_no_td_a_td` 

## Cuando entró bug
Bug entro en PR: https://github.com/gisce/gestionatr/pull/159