### PR TITLE
Mejorar el método "get_coeficient_repartiment" para que tenga en cuenta los periodos según la tarifa

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -505,7 +505,7 @@ class Factura(object):
                                 if periode and (float(periode.Beta.text) or float(periode.Beta.text) == 0.0):
                                     beta_list.append(float(periode.Beta.text))
                 # If it's a 2.0TD and we have 6 periods, we pop the last 3 (P4, P5, P6)
-                if self.factura.datos_factura.tarifa_atr_fact == '018' and len(beta_list) == 6:
+                if self.datos_factura.tarifa_atr_fact == '018' and len(beta_list) == 6:
                     beta_list = beta_list[:len(beta_list)-3]
                 return list(set(beta_list))
         except AttributeError:

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -504,6 +504,9 @@ class Factura(object):
                             for periode in terme.Periodo:
                                 if periode and (float(periode.Beta.text) or float(periode.Beta.text) == 0.0):
                                     beta_list.append(float(periode.Beta.text))
+                # If it's a 2.0TD and we have 6 periods, we pop the last 3 (P4, P5, P6)
+                if self.factura.datos_factura.tarifa_atr_fact == '018' and len(beta_list) == 6:
+                    beta_list = beta_list[:len(beta_list)-3]
                 return list(set(beta_list))
         except AttributeError:
             # We might not have any "Coeficient de repartiment" in EnergiaNetaGen


### PR DESCRIPTION
Si la tarifa es 2.0TD y el F1 indica valor de coeficiente de reparto para los 6 periodos, se eliminan los periodos P4, P5, Y P6 ya que no corresponden a esa tarifa.