### PR TITLE
Permitir obtener lecturas del F1 si el CG tiene mas periodos que la tarifa del contrato

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -2000,8 +2000,11 @@ class FacturaATR(Factura):
         base_lectura = None
         for l in lectures:
             if l.tipus == tipus:
-                lectures_per_periode[l.periode].append(l)
-                base_lectura = l
+                # Mandanga (Puta Fenosa) En cas que ens arribin lectures de periodes fora de la tarifa del contracte
+                # ignorem les lectures dels periodes que estiguin fora de la tarifa ATR del contracte
+                if l.periode in lectures_per_periode.keys():
+                    lectures_per_periode[l.periode].append(l)
+                    base_lectura = l
 
         if not base_lectura:
             return [x for x in lectures if x.tipus == tipus]


### PR DESCRIPTION
## Objetivos

Si nos envian las lecturas de Activa del contador de generación, y este está configurado con 6 periodos, pero el contrato tenia una tarifa ATR de 3 periodos, fallaba al obtener las lecturas.

Por ese motivo, a partir de ahora se ignoran las lecturas del contador cuyo periodo esté fuera de los periodos de la tarifa del contrato