### PR TITLE
Corrección validación numero expediente acometida cuando es motivo consulta 02

### DIFF
--- a/gestionatr/input/messages/R1.py
+++ b/gestionatr/input/messages/R1.py
@@ -1239,7 +1239,7 @@ class MinimumFieldsChecker(object):
 
     def check_sol_nuevos_suministro(self):
         for var in self.r1.variables_detalle_reclamacion:
-            if not var.num_expediente_acometida:
+            if not var.num_expediente_acometida and var.motivo_consulta == '02':
                 return False
         return len(self.r1.variables_detalle_reclamacion) > 0
 


### PR DESCRIPTION
Corrección en la validación de un R1 -03 tipo 076 "CONSULTA SEGUIMIENTO AUTOCONSUMO" en que, solicita número de acometida incorrectamente. Es obligatorio cuándo únicamente el motivo de consulta es tipo 02. 