### PR TITLE
Asignar precios de cargos correctamente cuando esten agrupados

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -596,7 +596,7 @@ class Factura(object):
             res[tipus_join]['total'] += info['total']
             for l in info['lines']:
                 for l2 in res[tipus_join]['lines']:
-                    if l2.nombre == l.nombre and l2.cantidad == l.cantidad:
+                    if l2.nombre == l.nombre and l2.fecha_desde >= l.fecha_desde and l2.fecha_hasta <= l.fecha_hasta:
                         l2.precio += round(l.precio*base, 9)
 
         return res


### PR DESCRIPTION
TEST: https://github.com/gisce/gestionatr/pull/272

En ocasiones en los F1 nos encontramos con diferentes etapas donde nos muestra el valor de la energía para cada periodo:

```
<EnergiaActiva>
<TerminoEnergiaActiva>
<FechaDesde>2022-10-19</FechaDesde>
<FechaHasta>2022-12-31</FechaHasta>
<Periodo>
<ValorEnergiaActiva>+00000000032.61</ValorEnergiaActiva>
<PrecioEnergia>00000.02778700</PrecioEnergia>
</Periodo>
...
<TerminoEnergiaActiva>
<FechaDesde>2022-12-31</FechaDesde>
<FechaHasta>2023-12-31</FechaHasta>
<Periodo>
<ValorEnergiaActiva>-00000000000.24</ValorEnergiaActiva>
<PrecioEnergia>00000.02909800</PrecioEnergia>
</Periodo>
<Periodo>
```

Pero los cargos de la energía se agrupan de la siguiente forma:
```
<TerminoCargo>
<FechaDesde>2022-12-31</FechaDesde>
<FechaHasta>2024-01-31</FechaHasta>
<Periodo>
<Energia>+00000000032.85</Energia>
<PrecioCargo>00000.043893000</PrecioCargo>
</Periodo>
<Periodo>
```

# FUNCIONAMIENTO ANTIGUO:
- Los cargos se sumaban comparando la cantidad de energía del cargo con la cantidad de energía del Término de Energía Activa, pero en este caso donde los cargos se agrupan, las cantidades de energía se suman y por lo tanto no se aplicaban nunca los cargos de energía.

# FUNCIONAMIENTO NUEVO:
- El nuevo funcionamiento busca los términos de energía a los que se tienen que aplicar los cargos a través de las fechas y no a través de la cantidad de energía.
