### PR TITLE
Nuevos métodos para obtener lecturas AS sin calcular ajustes

### DIFF
--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1686,14 +1686,12 @@ class ModeloAparato(object):
                 and not self.factura.has_AS_lectures():
             # Si no tenim lectures AS pero si que ens han cobrat excedents,
             # creem unes lectures AS ficticies a 0 (puta ENDESA)
-            comptador_base = (lectures and lectures[0].comptador) or None
-            lectures.extend(self.factura.get_fake_AS_lectures(comptador_base=comptador_base))
+            lectures.extend(self.factura.get_fake_AS_lectures(comptador_base=self))
         if (not tipus or "S" in tipus) and self.factura and self.factura.has_AS_lectures_only_p0() \
                 and len(self.factura.get_consum_facturat(tipus='S', periode=None)) > 1:
             # Si nomes ens envien el P0 de excedents pero ens cobren varis periodes
             # creem una lectura e P2 AS ficticies a 0 (puta FENOSA)
-            comptador_base = (lectures and lectures[0].comptador) or None
-            lectures.extend(self.factura.get_fake_AS_p2_lectures(comptador_base=comptador_base))
+            lectures.extend(self.factura.get_fake_AS_p2_lectures(comptador_base=self))
 
         if not force_no_transforma_no_td_a_td and self.factura:
             lectures = self.factura.transforma_no_td_a_td(

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1707,6 +1707,9 @@ class ModeloAparato(object):
     def get_lectures_activa_sortint(self):
         return self.get_lectures(['S'])
 
+    def get_lectures_activa_sortint_sense_quadrar_ajustos(self):
+        return self.get_lectures(['S'], force_no_transforma_no_td_a_td=True)
+
     def get_lectures_reactiva(self):
         return self.get_lectures(['R'])
 
@@ -2429,8 +2432,8 @@ class FacturaATR(Factura):
     def get_lectures_activa_entrant(self, ajust_balancejat=True, motiu_ajust="98"):
         return self.get_lectures_amb_ajust_quadrat_amb_consum(tipus='A', ajust_balancejat=ajust_balancejat, motiu_ajust=motiu_ajust)
 
-    def get_lectures_activa_sortint(self, ajust_balancejat=True, motiu_ajust="98"):
-        return self.get_lectures_amb_ajust_quadrat_amb_consum(tipus='S', ajust_balancejat=ajust_balancejat, motiu_ajust=motiu_ajust)
+    def get_lectures_activa_sortint(self, ajust_balancejat=True, motiu_ajust="98", lectures=None):
+        return self.get_lectures_amb_ajust_quadrat_amb_consum(tipus='S', ajust_balancejat=ajust_balancejat, motiu_ajust=motiu_ajust, lectures=lectures)
 
     def get_comptadors(self):
         """Retorna totes les lectures en una llista de comptadors"""

--- a/gestionatr/input/messages/F1.py
+++ b/gestionatr/input/messages/F1.py
@@ -1683,13 +1683,13 @@ class ModeloAparato(object):
                 and not self.factura.has_AS_lectures():
             # Si no tenim lectures AS pero si que ens han cobrat excedents,
             # creem unes lectures AS ficticies a 0 (puta ENDESA)
-            lectures.extend(self.factura.get_fake_AS_lectures())
+            lectures.extend(self.factura.get_fake_AS_lectures(comptador_base=lectures[0].comptador))
         if (not tipus or "S" in tipus) and self.factura and self.factura.has_AS_lectures_only_p0() \
                 and len(self.factura.get_consum_facturat(tipus='S', periode=None)) > 1 \
                 and self.factura.datos_factura.tarifa_atr_fact in ['004', '006', '007', '008']:
             # Si nomes ens envien el P0 de excedents pero ens cobren varis periodes
             # creem una lectura e P2 AS ficticies a 0 (puta FENOSA)
-            lectures.extend(self.factura.get_fake_AS_p2_lectures())
+            lectures.extend(self.factura.get_fake_AS_p2_lectures(comptador_base=lectures[0].comptador))
 
         if not force_no_transforma_no_td_a_td and self.factura:
             lectures = self.factura.transforma_no_td_a_td(
@@ -2240,7 +2240,7 @@ class FacturaATR(Factura):
                     pass
         return has_p0
 
-    def get_fake_AS_lectures(self):
+    def get_fake_AS_lectures(self, comptador_base=None):
         res = []
         comptador_amb_lectures = None
         for medida in self.medidas:
@@ -2265,6 +2265,9 @@ class FacturaATR(Factura):
                 l2.lectura = 0
                 l2.procedencia = base_info.lectura_hasta.procedencia
                 new_integrador = Integrador(base_info.integrador)
+                if comptador_base:
+                    new_integrador.comptador = comptador_base
+                new_integrador.comptador = base_info.comptador
                 new_integrador.magnitud = "AS"
                 new_integrador.numero_ruedas_enteras = base_info.numero_ruedas_enteras
                 new_integrador.codigo_periodo = base_info.codigo_periodo[0] + str(i)
@@ -2275,7 +2278,7 @@ class FacturaATR(Factura):
                 res.append(new_integrador)
         return res
 
-    def get_fake_pX_lectura(self, tipus, periode, base_info, lectura_desde=0, lectura_hasta=0):
+    def get_fake_pX_lectura(self, tipus, periode, base_info, lectura_desde=0, lectura_hasta=0, comptador_base=None):
         l1 = Lectura(None)
         l1.fecha = base_info.lectura_desde.fecha
         l1.lectura = lectura_desde
@@ -2286,6 +2289,8 @@ class FacturaATR(Factura):
         l2.procedencia = base_info.lectura_hasta.procedencia
 
         new_integrador = Integrador(None)
+        if comptador_base:
+            new_integrador.comptador = comptador_base
         new_integrador.magnitud = {v: k for k, v in MAGNITUDS_OCSUM.iteritems()}.get(tipus, tipus)
         new_integrador.numero_ruedas_enteras = base_info.numero_ruedas_enteras
         new_integrador.codigo_periodo = periode
@@ -2308,7 +2313,7 @@ class FacturaATR(Factura):
 
         return new_integrador
 
-    def get_fake_AS_p2_lectures(self):
+    def get_fake_AS_p2_lectures(self, comptador_base=None):
         res = []
         comptador_amb_lectures = None
         for medida in self.medidas:
@@ -2335,6 +2340,8 @@ class FacturaATR(Factura):
                 l2.lectura = 0
                 l2.procedencia = base_info.lectura_hasta.procedencia
                 new_integrador = Integrador(None)
+                if comptador_base:
+                    new_integrador.comptador = comptador_base
                 new_integrador.magnitud = "AS"
                 new_integrador.numero_ruedas_enteras = base_info.numero_ruedas_enteras
                 new_integrador.codigo_periodo = base_info.codigo_periodo[0] + str(i)


### PR DESCRIPTION
## Nuevas funcionalidades

- `compt_xml.get_lectures_activa_sortint_sense_quadrar_ajustos` -> Nuevo método para obtener las lecturas de activa saliente sin calcular ajustes.
- `fact_xml.get_lectures_activa_sortint` -> Nuevo named param `lectures:None`, para poder indicar las lecturas sobre las cuales se tienen que cuadrar los ajustes.
- `compt_xml.get_fake_AS_lectures`-> Nuevo named param `comptador_base:None`, para poder asignar el contador de la lectura original a las lecturas ficticias.
- `compt_xml.get_fake_pX_lectura`-> Nuevo named param `comptador_base:None`, para poder asignar el contador de la lectura original a las lecturas ficticias
- `compt_xml.get_fake_AS_p2_lectures`-> Nuevo named param `comptador_base:None`, para poder asignar el contador de la lectura original a las lecturas ficticias