### PR TITLE
Corregir función check_disconformidad_autoconsumo

### DIFF
--- a/gestionatr/input/messages/R1.py
+++ b/gestionatr/input/messages/R1.py
@@ -1119,7 +1119,7 @@ class MinimumFieldsChecker(object):
                 errors.append(field)
         return errors
 
-    def check_tipo_disconforme_autoconsumo(self):
+    def check_disconformidad_autoconsumo(self):
         for var in self.r1.variables_detalle_reclamacion:
             if not var.disconformidad_autoconsumo:
                 return False


### PR DESCRIPTION
Se ha renombrado la función para adaptarla al nombre del campo a comprobar.

