### PR TITLE
Corregir literales por carácteres más comunes.

### DIFF
--- a/gestionatr/defs.py
+++ b/gestionatr/defs.py
@@ -833,8 +833,8 @@ TABLA_17 = [
     ('025', '6.1TDVE'),
     ('026', '6.2TDVE'),
     ('027', '3.0TDVE - Embarcaciones'),
-    ('028', '6.1TDVE – Embarcaciones'),
-    ('029', '6.2TDVE – Embarcaciones'),
+    ('028', '6.1TDVE - Embarcaciones'),
+    ('029', '6.2TDVE - Embarcaciones'),
 ]
 
 TABLA_20 = [
@@ -2342,8 +2342,8 @@ TABLA_107 = [
     ('025',  u'6.1TDVE'),
     ('026',  u'6.2TDVE'),
     ('027',  u'3.0TDVE - Embarcaciones'),
-    ('028',  u'6.1TDVE – Embarcaciones'),
-    ('029',  u'6.2TDVE – Embarcaciones'),
+    ('028',  u'6.1TDVE - Embarcaciones'),
+    ('029',  u'6.2TDVE - Embarcaciones'),
 ]
 
 TABLA_108 = [('01', u'Mensual'),
@@ -2399,27 +2399,27 @@ CONV_T109_T111 = {'01': '01',  # TG with CCH
 
 TABLA_113 = [
     ('00', u'Sin Autoconsumo'),
-    ('31', u'Sin Excedentes Individual – Consumo'),
-    ('32', u'Sin Excedentes Colectivo – Consumo'),
-    ('33', u'Sin Excedentes Colectivo con acuerdo de compensación – Consumo'),
+    ('31', u'Sin Excedentes Individual - Consumo'),
+    ('32', u'Sin Excedentes Colectivo - Consumo'),
+    ('33', u'Sin Excedentes Colectivo con acuerdo de compensación - Consumo'),
     ('41', u'Con excedentes y compensación Individual - Consumo'),
-    ('42', u'Con excedentes y compensación Colectivo– Consumo'),
-    ('43', u'Con excedentes y compensación Colectivo a través de red– Consumo'),
-    ('51', u'Con excedentes sin compensación Individual sin cto de SSAA en Red Interior– Consumo'),
-    ('52', u'Con excedentes sin compensación Colectivo sin cto de SSAA en Red Interior– Consumo'),
-    ('53', u'Con excedentes sin compensación Individual con cto SSAA en Red Interior– Consumo'),
-    ('54', u'Con excedentes sin compensación individual con cto SSAA en Red Interior– SSAA'),
-    ('55', u'Con excedentes sin compensación Colectivo/en Red Interior– Consumo'),
+    ('42', u'Con excedentes y compensación Colectivo - Consumo'),
+    ('43', u'Con excedentes y compensación Colectivo a través de red - Consumo'),
+    ('51', u'Con excedentes sin compensación Individual sin cto de SSAA en Red Interior - Consumo'),
+    ('52', u'Con excedentes sin compensación Colectivo sin cto de SSAA en Red Interior - Consumo'),
+    ('53', u'Con excedentes sin compensación Individual con cto SSAA en Red Interior - Consumo'),
+    ('54', u'Con excedentes sin compensación individual con cto SSAA en Red Interior - SSAA'),
+    ('55', u'Con excedentes sin compensación Colectivo/en Red Interior - Consumo'),
     ('56', u'Con excedentes sin compensación Colectivo/en Red Interior - SSAA'),
-    ('57', u'Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior – Consumo'),
+    ('57', u'Con excedentes sin compensación Colectivo sin cto de SSAA (despreciable) en red interior - Consumo'),
     ('58', u'Con excedentes sin compensación Colectivo sin cto de SSAA a través de red - Consumo'),
-    ('61', u'Con excedentes sin compensación Individual con cto SSAA a través de red – Consumo'),
-    ('62', u'Con excedentes sin compensación individual con cto SSAA a través de red – SSAA'),
-    ('63', u'Con excedentes sin compensación Colectivo a través de red – Consumo'),
+    ('61', u'Con excedentes sin compensación Individual con cto SSAA a través de red - Consumo'),
+    ('62', u'Con excedentes sin compensación individual con cto SSAA a través de red - SSAA'),
+    ('63', u'Con excedentes sin compensación Colectivo a través de red - Consumo'),
     ('64', u'Con excedentes sin compensación Colectivo a través de red - SSAA'),
-    ('71', u'Con excedentes sin compensación Individual con cto SSAA a través de red y red interior – Consumo'),
-    ('72', u'Con excedentes sin compensación individual con cto SSAA a través de red y red interior – SSAA'),
-    ('73', u'Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior – Consumo'),
+    ('71', u'Con excedentes sin compensación Individual con cto SSAA a través de red y red interior - Consumo'),
+    ('72', u'Con excedentes sin compensación individual con cto SSAA a través de red y red interior - SSAA'),
+    ('73', u'Con excedentes sin compensación Colectivo con cto de SSAA  a través de red y red interior - Consumo'),
     ('74', u'Con excedentes sin compensación Colectivo con cto de SSAA a través de red y red interior - SSAA'),
 ]
 # es posa NEW perque no es un canvi que afecti a tot el ERP ja que REE encara utilitza els formats antics. Quan REE
@@ -2442,7 +2442,7 @@ TABLA_114 = [
 TABLA_115 = PERSONA
 
 TABLA_116 = [
-    ('0', u'No Bono Social – Retirada del BS'),
+    ('0', u'No Bono Social - Retirada del BS'),
     ('1', u'Bono Social'),
 ]
 
@@ -2454,8 +2454,8 @@ TABLA_117 = [
 ]
 
 TABLA_118 = [
-    ('01', u'Vuelta a la situación anterior – En servicio'),
-    ('02', u'Vuelta a la situación anterior – Sin servicio (cortado)'),
+    ('01', u'Vuelta a la situación anterior - En servicio'),
+    ('02', u'Vuelta a la situación anterior - Sin servicio (cortado)'),
     ('03', u'Traspaso a la COR'),
     ('04', u'Baja del contrato por rechazo de la COR'),
     ('05', u'Baja por cese de actividad'),
@@ -2668,8 +2668,8 @@ TABLA_133 = [
 ]
 
 TABLA_134 = [
-    ('01', u'Vuelta a la situación anterior – En servicio'),
-    ('02', u'Vuelta a la situación anterior – En servicio (cortado)'),
+    ('01', u'Vuelta a la situación anterior - En servicio'),
+    ('02', u'Vuelta a la situación anterior - En servicio (cortado)'),
     ('03', u'Traspaso a la COR'),
     ('05', u'Baja por cese de actividad'),
     ('06', u'Activación de cambio de comercializador'),


### PR DESCRIPTION
Ciertos literales del fichero defs utilizaban un carácter especial para el guión que no está disponible en ciertas fuentes.