### PR TITLE
A la hora de conseguir la lecturas de un B70 intentar ignorar el ajuste en la lectura si no los pasan por parámetro

### DIFF
--- a/gestionatr/input/messages/B70.py
+++ b/gestionatr/input/messages/B70.py
@@ -1315,7 +1315,7 @@ class Medidor(object):
                 data.append(Numerador(d))
         return data
 
-    def get_lectures_info(self):
+    def get_lectures_info(self, ignorar_ajust_incorrecte=None):
         res = []
         if not hasattr(self, 'meters'):
             self.meters = [self]
@@ -1381,6 +1381,19 @@ class Medidor(object):
                     'temperatura_gas': float(temperatura_gas),
                     'pressio_atmosferica': float(pressio_atmosferica),
                 }
+
+                # Si ens diuen de no tenir en compte l'ajust si es incorrecte validem si sense aplicar l'ajust el
+                # consum de kWh calculat a partir de les lectures es el mateix que el que informen en el B70. Si tot i
+                # no aplicar l'ajust el consum en kWh calculat no es igual al consum en kWh del B70 no toquem l'ajust i
+                # el deixem tal qual ve al B70
+                if ignorar_ajust_incorrecte and ajust:
+                    consum_kwh_b70 = round(consum_kwh_facturat, 3)
+                    calc_consum_m3 = round(vals['lectura_actual_m3'] - vals['lectura_desde_m3'], 3)
+                    consum_kwh_calculat = round(calc_consum_m3 * vals['pcs'] * vals['factor_k'] + vals['ajust'], 3)
+                    if consum_kwh_b70 != consum_kwh_calculat:
+                        consum_kwh_calculat_sense_ajust = round(calc_consum_m3 * vals['pcs'] * vals['factor_k'], 3)
+                        if consum_kwh_calculat_sense_ajust == consum_kwh_b70:
+                            vals.update({'ajust': 0})
 
                 # Si el consum que calculem amb el factor_k i el pcs no dona el consum calculat amb el factor de conversio
                 # pero si fem servir el factor de conversio informat per la distri si que dona, modfiquem el factor_k perque

--- a/gestionatr/input/messages/B70.py
+++ b/gestionatr/input/messages/B70.py
@@ -1315,7 +1315,7 @@ class Medidor(object):
                 data.append(Numerador(d))
         return data
 
-    def get_lectures_info(self, ignorar_ajust_incorrecte=None):
+    def get_lectures_info(self, **kwargs):
         res = []
         if not hasattr(self, 'meters'):
             self.meters = [self]
@@ -1386,17 +1386,20 @@ class Medidor(object):
                 # consum de kWh calculat a partir de les lectures es el mateix que el que informen en el B70. Si tot i
                 # no aplicar l'ajust el consum en kWh calculat no es igual al consum en kWh del B70 no toquem l'ajust i
                 # el deixem tal qual ve al B70
+                ignorar_ajust_incorrecte = kwargs.get('ignorar_ajust_incorrecte', False)
                 if ignorar_ajust_incorrecte and ajust:
                     consum_kwh_b70 = round(consum_kwh_facturat, 3)
                     consum_kwh_calculat = round(vals['consum_m3'] * vals['pcs'] * vals['factor_k'] + vals['ajust'], 3)
-                    if consum_kwh_b70 != consum_kwh_calculat:
+                    if abs(consum_kwh_b70 - consum_kwh_calculat) > 1.0:
                         consum_kwh_calculat_sense_ajust = round(vals['consum_m3'] * vals['pcs'] * vals['factor_k'], 3)
                         if consum_kwh_calculat_sense_ajust == consum_kwh_b70:
                             vals.update({'ajust': 0})
                             ajust = 0
-                        elif abs(consum_kwh_calculat_sense_ajust - consum_kwh_b70) < 1.0:  # Si diferencia es menor 1kWh
-                                vals.update({'ajust': 0})
-                                ajust = 0
+                        # Si ni el consum calculat sense ajust coincideix amb el consum kwh del B70 revisem si la
+                        # diferencia es menor a una tolerancia
+                        elif abs(consum_kwh_calculat_sense_ajust - consum_kwh_b70) <= 1.0:
+                            vals.update({'ajust': 0})
+                            ajust = 0
 
                 # Si el consum que calculem amb el factor_k i el pcs no dona el consum calculat amb el factor de conversio
                 # pero si fem servir el factor de conversio informat per la distri si que dona, modfiquem el factor_k perque

--- a/gestionatr/input/messages/B70.py
+++ b/gestionatr/input/messages/B70.py
@@ -1388,12 +1388,15 @@ class Medidor(object):
                 # el deixem tal qual ve al B70
                 if ignorar_ajust_incorrecte and ajust:
                     consum_kwh_b70 = round(consum_kwh_facturat, 3)
-                    calc_consum_m3 = round(vals['lectura_actual_m3'] - vals['lectura_desde_m3'], 3)
-                    consum_kwh_calculat = round(calc_consum_m3 * vals['pcs'] * vals['factor_k'] + vals['ajust'], 3)
+                    consum_kwh_calculat = round(vals['consum_m3'] * vals['pcs'] * vals['factor_k'] + vals['ajust'], 3)
                     if consum_kwh_b70 != consum_kwh_calculat:
-                        consum_kwh_calculat_sense_ajust = round(calc_consum_m3 * vals['pcs'] * vals['factor_k'], 3)
+                        consum_kwh_calculat_sense_ajust = round(vals['consum_m3'] * vals['pcs'] * vals['factor_k'], 3)
                         if consum_kwh_calculat_sense_ajust == consum_kwh_b70:
                             vals.update({'ajust': 0})
+                            ajust = 0
+                        elif abs(consum_kwh_calculat_sense_ajust - consum_kwh_b70) < 1.0:  # Si diferencia es menor 1kWh
+                                vals.update({'ajust': 0})
+                                ajust = 0
 
                 # Si el consum que calculem amb el factor_k i el pcs no dona el consum calculat amb el factor de conversio
                 # pero si fem servir el factor de conversio informat per la distri si que dona, modfiquem el factor_k perque


### PR DESCRIPTION
Cuando llaman a la función `get_lectures_info` indicando que quieren ignorar el ajuste cogemos el consumo en m3 y le aplicamos el factor de conversión sin aplicar el ajuste para obtener los kWh de consumo. Si obtenemos los mismos kWh que los que informa el campo `consumokwh` del B70 ponemos el ajuste a 0 ya que se entiende que el ajuste es incorrecto